### PR TITLE
Fix validate.sh on macOS: head -n -1 is GNU-only

### DIFF
--- a/skills/okf-open-knowledge-format/scripts/validate.sh
+++ b/skills/okf-open-knowledge-format/scripts/validate.sh
@@ -65,7 +65,7 @@ while IFS= read -r -d '' file; do
   fi
 
   # Extract frontmatter (between first --- and second ---)
-  frontmatter=$(sed -n '2,/^---$/p' "$file" | head -n -1)
+  frontmatter=$(sed -n '2,/^---$/p' "$file" | sed '$d')
 
   # E2: Check for non-empty type field
   type_value=$(echo "$frontmatter" | grep -E "^type:" | sed 's/^type:\s*//' | tr -d '"' | tr -d "'" | xargs)


### PR DESCRIPTION
Thanks for putting this skill together — it's been really handy. 🙏

A note on provenance, for honesty's sake: I hit this while using the `okf-open-knowledge-format` skill on macOS through an AI coding agent (Claude Code). The agent is the one that reproduced and diagnosed the issue and proposed the one-line fix below — I'm just relaying it upstream so other macOS users don't hit the same wall. Credit for the catch is the agent's, not mine.

## The problem

On macOS, `skills/okf-open-knowledge-format/scripts/validate.sh` aborts without producing any output.

Line 68 uses `head -n -1` (print all lines but the last), a **GNU coreutils** extension. macOS ships **BSD `head`**, which rejects negative line counts:

```
$ printf 'a\nb\nc\n' | head -n -1
head: illegal line count -- -1
```

Since the script runs under `set -euo pipefail` (line 9), that failing pipe makes the assignment non-zero and the whole script exits at the first concept file — no `Files scanned` summary, no verdict.

## The fix

Swap the GNU-only `head -n -1` for the POSIX `sed '$d'` (delete last line) — identical on BSD and GNU:

```diff
- frontmatter=$(sed -n '2,/^---$/p' "$file" | head -n -1)
+ frontmatter=$(sed -n '2,/^---$/p' "$file" | sed '$d')
```

## Testing

- Before (macOS): errors with `head: illegal line count -- -1`, no verdict.
- After (macOS): runs to completion and prints the conformance summary.
- `sed '$d'` yields the same frontmatter block `head -n -1` produces on Linux.
- `sort -z` (line 88) was also checked and works on macOS, so this is the only portability issue.

Totally fine to adjust the wording or approach if you'd prefer — thanks again!

**Environment:** macOS (BSD `head`), bash 3.2.
